### PR TITLE
Bugfix in Parser clean() method

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -149,7 +149,7 @@ class Parser
      */
     protected function parseLine($line)
     {
-        $split = preg_split('/\s/ ', $line, 2);
+        $split = preg_split('/\s/', $line, 2);
 
         return array(
             'key' => $split[0],
@@ -497,7 +497,7 @@ class Parser
                 $value[$k] = $this->clean($v);
             }
         } else {
-            $value = trim($value, '"');
+            $value = preg_replace('/^\"|\"$/', '', $value);
             $value = stripcslashes($value);
         }
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -230,6 +230,14 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 'plural' => false,
                 'flags' => array()
             ),
+            array(
+                'msgid' => '"Stay in quotation"',
+                'msgstr' => 'Lass die " am Ende stehen',
+                'fuzzy' => false,
+                'obsolete' => false,
+                'plural' => false,
+                'flags' => array()
+            ),
         );
     }
 

--- a/tests/data/general.po
+++ b/tests/data/general.po
@@ -53,3 +53,6 @@ msgstr[1] "very long translation2"
 
 #~ msgid "hare"
 #~ msgstr "liebre"
+
+msgid "\"Stay in quotation\""
+msgstr "Lass die \" am Ende stehen"


### PR DESCRIPTION
- Now only trimming quotation marks only once at beginning and end of line to prevent breaking wanted quotes at the end of a string like `msgid "This is supposed to be in \"quotation marks\""`
- Added tests for bugfix
