### PR TITLE
Fixed updating entires with plural form

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -439,22 +439,68 @@ class Parser
     }
 
     /**
-     * Allows modification a msgid.
-     * By default disabled fuzzy flag if defined.
+     * Helper for the update-functions by deleting the fuzzy flag
      *
-     * @param $original
-     * @param $translation
+     * @param $msgid string msgid of entry
+     *
+     * @throws \Exception
      */
-    public function updateEntry($original, $translation)
+    protected function removeFuzzyFlagForMsgId($msgid)
     {
-        $this->entriesAsArrays[$original]['fuzzy'] = false;
-        $this->entriesAsArrays[$original]['msgstr'] = array($translation);
-
-        $flags = $this->entriesAsArrays[$original]['flags'];
-        unset($flags[array_search('fuzzy', $flags, true)]);
-        $this->entriesAsArrays[$original]['flags'] = $flags;
+        if (!isset($this->entriesAsArrays[$msgid])) {
+            throw new \Exception('Entry does not exist');
+        }
+        if ($this->entriesAsArrays[$msgid]['fuzzy']) {
+            $flags = $this->entriesAsArrays[$msgid]['flags'];
+            unset($flags[array_search('fuzzy', $flags, true)]);
+            $this->entriesAsArrays[$msgid]['flags'] = $flags;
+            $this->entriesAsArrays[$msgid]['fuzzy'] = false;
+        }
     }
 
+    /**
+     * Allows modifaction of all translations of an entry
+     *
+     * @param $msgid string msgid of the entry which should be updated
+     * @param $translation array of strings new Translation for all msgstr by msgid
+     *
+     * @throws \Exception
+     */
+    public function updateEntries($msgid, $translation)
+    {
+        if (
+            !isset($this->entriesAsArrays[$msgid])
+            or !is_array($translation)
+            or sizeof($translation) != sizeof($this->entriesAsArrays[$msgid]['msgstr'])
+        ) {
+            throw new \Exception('Entry could not update the given translation');
+        }
+        $this->removeFuzzyFlagForMsgId($msgid);
+        $this->entriesAsArrays[$msgid]['msgstr'] = $translation;
+    }
+
+    /**
+     * Allows modifaction of one translations of an entry
+     *
+     * @param $msgid string msgid of the entry which should be updated
+     * @param $translation string new translation for an msgstr by msgid
+     * @param $positionMsgstr integer spezification which of the msgstr
+     *      should be changed
+     *
+     * @throws \Exception
+     */
+    public function updateEntry($msgid, $translation, $positionMsgstr = 0)
+    {
+        if (
+            !isset($this->entriesAsArrays[$msgid])
+            or !is_string($translation)
+            or !isset($this->entriesAsArrays[$msgid]['msgstr'][$positionMsgstr])
+        ) {
+            throw new \Exception('Entry could not update the given translation');
+        }
+        $this->removeFuzzyFlagForMsgId($msgid);
+        $this->entriesAsArrays[$msgid]['msgstr'][$positionMsgstr] = $translation;
+    }
 
     /**
      * Write entries into the po file.

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -459,7 +459,7 @@ class Parser
     }
 
     /**
-     * Allows modifaction of all translations of an entry
+     * Allows modification of all translations of an entry
      *
      * @param $msgid string msgid of the entry which should be updated
      * @param $translation array of strings new Translation for all msgstr by msgid
@@ -470,17 +470,17 @@ class Parser
     {
         if (
             !isset($this->entriesAsArrays[$msgid])
-            or !is_array($translation)
-            or sizeof($translation) != sizeof($this->entriesAsArrays[$msgid]['msgstr'])
+            || !is_array($translation)
+            || sizeof($translation) != sizeof($this->entriesAsArrays[$msgid]['msgstr'])
         ) {
-            throw new \Exception('Entry could not update the given translation');
+            throw new \Exception('Cannot update entry translation');
         }
         $this->removeFuzzyFlagForMsgId($msgid);
         $this->entriesAsArrays[$msgid]['msgstr'] = $translation;
     }
 
     /**
-     * Allows modifaction of one translations of an entry
+     * Allows modification of a single translation of an entry
      *
      * @param $msgid string msgid of the entry which should be updated
      * @param $translation string new translation for an msgstr by msgid
@@ -493,10 +493,10 @@ class Parser
     {
         if (
             !isset($this->entriesAsArrays[$msgid])
-            or !is_string($translation)
-            or !isset($this->entriesAsArrays[$msgid]['msgstr'][$positionMsgstr])
+            || !is_string($translation)
+            || !isset($this->entriesAsArrays[$msgid]['msgstr'][$positionMsgstr])
         ) {
-            throw new \Exception('Entry could not update the given translation');
+            throw new \Exception('Cannot update entry translation');
         }
         $this->removeFuzzyFlagForMsgId($msgid);
         $this->entriesAsArrays[$msgid]['msgstr'][$positionMsgstr] = $translation;

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -364,7 +364,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testFailUpdateEntryNotInArray()
     {
-        $this->setExpectedException('\Exception', 'Entry could not update the given translation');
+        $this->setExpectedException('\Exception', 'Cannot update entry translation');
         $this->parser->read(TEST_DATA_PATH . '/general.po');
 
         $this->parser->updateEntry('NOT IN PO', 'Ist nicht in Po');
@@ -376,7 +376,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testFailUpdateEntryNotAString()
     {
-        $this->setExpectedException('\Exception', 'Entry could not update the given translation');
+        $this->setExpectedException('\Exception', 'Cannot update entry translation');
         $this->parser->read(TEST_DATA_PATH . '/general.po');
 
         $this->parser->updateEntry('cookie', array('Keks'));
@@ -388,7 +388,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testFailUpdateEntryNotExistingTranslationPosition()
     {
-        $this->setExpectedException('\Exception', 'Entry could not update the given translation');
+        $this->setExpectedException('\Exception', 'Cannot update entry translation');
         $this->parser->read(TEST_DATA_PATH . '/general.po');
 
         $this->parser->updateEntry('cookie', 'Keks', 5);
@@ -400,7 +400,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testFailUpdateEntriesNotInArray()
     {
-        $this->setExpectedException('\Exception', 'Entry could not update the given translation');
+        $this->setExpectedException('\Exception', 'Cannot update entry translation');
         $this->parser->read(TEST_DATA_PATH . '/general.po');
 
         $this->parser->updateEntries('NOT IN PO', array('Ist nicht in Po'));
@@ -412,7 +412,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testFailUpdateEntriesNotAnArray()
     {
-        $this->setExpectedException('\Exception', 'Entry could not update the given translation');
+        $this->setExpectedException('\Exception', 'Cannot update entry translation');
         $this->parser->read(TEST_DATA_PATH . '/general.po');
 
         $this->parser->updateEntries('cookie', 'Keks');
@@ -424,7 +424,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testFailUpdateEntriesNotEqualAmountOfTranslations()
     {
-        $this->setExpectedException('\Exception', 'Entry could not update the given translation');
+        $this->setExpectedException('\Exception', 'Cannot update entry translation');
         $this->parser->read(TEST_DATA_PATH . '/general.po');
 
         $this->parser->updateEntries('cookie', array('Keks'));

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -238,6 +238,15 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 'plural' => false,
                 'flags' => array()
             ),
+            array(
+                'msgid' => 'cookie',
+                'msgid_plural' => 'cookies',
+                'msgstr' => array('biscuit', 'biscuits'),
+                'fuzzy' => true,
+                'obsolete' => false,
+                'plural' => true,
+                'flags' => array('fuzzy', 'other-flag')
+            ),
         );
     }
 
@@ -340,5 +349,103 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $entries = $this->parser->getEntriesAsArrays();
         $this->assertEquals('mapache2', $entries['racoon']['msgstr'][0]);
         $this->assertFalse($entries['racoon']['fuzzy']);
+
+        // checking if plural msgstr still existing bevor changing the updateEntry-function
+        $pluralmsgstr = isset($entries['cookie']['msgstr'][1]);
+        $this->parser->updateEntry('cookie', 'Keks');
+        $entries = $this->parser->getEntriesAsArrays();
+        $this->assertEquals('Keks', $entries['cookie']['msgstr'][0]);
+        $this->assertEquals($pluralmsgstr, isset($entries['cookie']['msgstr'][1]));
+    }
+
+    /**
+     * Test if exception is thrown, when in the updateEntry-Function:
+     * if the given msgid is not an entry
+     */
+    public function testFailUpdateEntryNotInArray()
+    {
+        $this->setExpectedException('\Exception', 'Entry could not update the given translation');
+        $this->parser->read(TEST_DATA_PATH . '/general.po');
+
+        $this->parser->updateEntry('NOT IN PO', 'Ist nicht in Po');
+    }
+
+    /**
+     * Test if exception is thrown, when in the updateEntry-Function:
+     * when the given parameter for the translation isn't a string
+     */
+    public function testFailUpdateEntryNotAString()
+    {
+        $this->setExpectedException('\Exception', 'Entry could not update the given translation');
+        $this->parser->read(TEST_DATA_PATH . '/general.po');
+
+        $this->parser->updateEntry('cookie', array('Keks'));
+    }
+
+    /**
+     * Test if exception is thrown, when in the updateEntry-Function:
+     * when the given parameter for the translationPosition doesn't exist
+     */
+    public function testFailUpdateEntryNotExistingTranslationPosition()
+    {
+        $this->setExpectedException('\Exception', 'Entry could not update the given translation');
+        $this->parser->read(TEST_DATA_PATH . '/general.po');
+
+        $this->parser->updateEntry('cookie', 'Keks', 5);
+    }
+
+    /**
+     * Test if exception is thrown, when in the updateEntries-Function:
+     * if the given msgid is not an entry
+     */
+    public function testFailUpdateEntriesNotInArray()
+    {
+        $this->setExpectedException('\Exception', 'Entry could not update the given translation');
+        $this->parser->read(TEST_DATA_PATH . '/general.po');
+
+        $this->parser->updateEntries('NOT IN PO', array('Ist nicht in Po'));
+    }
+
+    /**
+     * Test if exception is thrown, when in the updateEntries-Function:
+     * when the given parameter for the translation isn't an array
+     */
+    public function testFailUpdateEntriesNotAnArray()
+    {
+        $this->setExpectedException('\Exception', 'Entry could not update the given translation');
+        $this->parser->read(TEST_DATA_PATH . '/general.po');
+
+        $this->parser->updateEntries('cookie', 'Keks');
+    }
+
+    /**
+     * Test if exception is thrown, when in the updateEntries-Function:
+     * in the given Array isn't the same amount of translation like before
+     */
+    public function testFailUpdateEntriesNotEqualAmountOfTranslations()
+    {
+        $this->setExpectedException('\Exception', 'Entry could not update the given translation');
+        $this->parser->read(TEST_DATA_PATH . '/general.po');
+
+        $this->parser->updateEntries('cookie', array('Keks'));
+    }
+
+    /**
+     *
+     */
+    public function testUpdateEntries()
+    {
+        $this->parser->read(TEST_DATA_PATH . '/general.po');
+
+        $entries = $this->parser->getEntriesAsArrays();
+        $this->assertEquals('biscuit', $entries['cookie']['msgstr'][0]);
+        $this->assertEquals('biscuits', $entries['cookie']['msgstr'][1]);
+        $this->assertTrue($entries['cookie']['fuzzy']);
+
+        $this->parser->updateEntries('cookie', array('Keks','Kekse'));
+        $entries = $this->parser->getEntriesAsArrays();
+        $this->assertEquals('Keks', $entries['cookie']['msgstr'][0]);
+        $this->assertEquals('Kekse', $entries['cookie']['msgstr'][1]);
+        $this->assertFalse($entries['cookie']['fuzzy']);
     }
 }

--- a/tests/data/general.po
+++ b/tests/data/general.po
@@ -56,3 +56,9 @@ msgstr[1] "very long translation2"
 
 msgid "\"Stay in quotation\""
 msgstr "Lass die \" am Ende stehen"
+
+#, fuzzy, other-flag
+msgid "cookie"
+msgid_plural "cookies"
+msgstr[0] "biscuit"
+msgstr[1] "biscuits"


### PR DESCRIPTION
Plural form could not be saved when using `updateEntry` method (plural form was deleted).

Here is a fix for that.
- updated Parser::updateEntry()
- added Parser::updateEntries()
- refactored removing fuzzy from Parser::updateEntry() into Parser::removeFuzzyFlagForMsgId()
- added tests
