### PR TITLE
More defensive

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -252,7 +252,7 @@ class Parser
                 $this->currentEntry['msgstr'][] = trim($line, '"');
                 break;
             default:
-                throw new \Exception('Parse error!');
+                //throw new \Exception('Parse error!');
         }
     }
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -252,7 +252,7 @@ class Parser
                 $this->currentEntry['msgstr'][] = trim($line, '"');
                 break;
             default:
-                //throw new \Exception('Parse error!');
+                throw new \Exception('Parse error!');
         }
     }
 
@@ -315,6 +315,9 @@ class Parser
         $counter = 0;
         foreach ($this->rawEntries as $entry) {
             $entry = $this->prepareEntry($entry, $counter);
+            if (!$entry) {
+                continue;
+            }
 
             $id = $this->getMsgId($entry);
 
@@ -328,12 +331,16 @@ class Parser
     }
 
     /**
-     * @param $entry
+     * @param string|array $entry
      *
      * @return string
      */
     protected function getMsgId($entry)
     {
+        if (!isset($entry['msgid'])) {
+            return null;
+        }
+
         return is_array($entry['msgid']) ? implode('', $entry['msgid']) : $entry['msgid'];
     }
 
@@ -350,6 +357,9 @@ class Parser
         }
 
         $id = $this->getMsgId($entry);
+        if ($id === null) {
+            return [];
+        }
 
         if ($index === 0 && $id === '') {
             //header entry


### PR DESCRIPTION
Some PO files contain just a inline

    ...    

    # Comment
    
    ...

Or something like that.
This should not trigger a complete parse error if possible.

This way it is a bit more resilient.
Does it look good?

  